### PR TITLE
interface to create PDF A4 with separation hint instead of scissors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbitgmbh/bbit.banking-utils",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "types": "dist/index.d.js",
   "main": "dist/index.js",

--- a/src/qr-bill/interfaces.ts
+++ b/src/qr-bill/interfaces.ts
@@ -28,6 +28,7 @@ export enum BbitQRBillFormat {
   DEFAULT_WITHOUT_LINES = 'default-without-lines',
   A4 = 'a4',
   A4_WITHOUT_LINES = 'a4-without-lines',
+  A4_WITH_SEPARATION_HINT = 'a4-with-separation-hint',
 }
 
 export enum BbitQRBillCurrency {
@@ -63,4 +64,5 @@ export interface IBbitQRBillTranslations {
   acceptancePoint: string;
   payableBy: string;
   payableByNameAddr: string;
+  separationHint?: string;
 }


### PR DESCRIPTION
These new interface are needed to add A4 PDF with separation hint format to the [swiss-qr-bill project](https://github.com/bbitgmbh/bbit.swiss-qr-bill/pull/171).